### PR TITLE
feat: better where clause query

### DIFF
--- a/cte_test.go
+++ b/cte_test.go
@@ -23,7 +23,7 @@ func TestWithCTE_RawString(t *testing.T) {
 
 func TestWithCTE_SubQuery(t *testing.T) {
 	sub := New[TestModel]()
-	sub.Where("age >", 18)
+	sub.Where("age", ">", 18)
 
 	m := New[TestModel]()
 	m.WithCTE("cte", sub)

--- a/errors.go
+++ b/errors.go
@@ -23,7 +23,7 @@ var (
 	// ErrNoContext is returned when no context is provided
 	ErrNoContext = errors.New("zorm: no context provided")
 
-	// Relation errors
+	// ErrRelationNotFound Relation errors
 	// ErrRelationNotFound is returned when a relation method is not found
 	ErrRelationNotFound = errors.New("zorm: relation not found")
 	// ErrInvalidRelation is returned when relation type is invalid
@@ -41,7 +41,7 @@ var (
 	// ErrNotNullViolation is returned for NOT NULL constraint violations
 	ErrNotNullViolation = errors.New("zorm: not null constraint violation")
 
-	// Connection errors
+	// ErrConnectionFailed Connection errors
 	// ErrConnectionFailed is returned when database connection fails
 	ErrConnectionFailed = errors.New("zorm: connection failed")
 	// ErrConnectionLost is returned when connection is lost during operation

--- a/executor.go
+++ b/executor.go
@@ -229,7 +229,7 @@ func (m *Model[T]) First(ctx context.Context) (*T, error) {
 
 // Find finds a record by ID.
 func (m *Model[T]) Find(ctx context.Context, id any) (*T, error) {
-	return m.Where(m.modelInfo.PrimaryKey+" = ?", id).First(ctx)
+	return m.Where(m.modelInfo.PrimaryKey, id).First(ctx)
 }
 
 // FindOrFail finds a record by ID or returns an error.

--- a/query_test.go
+++ b/query_test.go
@@ -66,7 +66,7 @@ func TestWhere_StringWithValue(t *testing.T) {
 
 // TestWhere_StringWithOperator tests Where with operator
 func TestWhere_StringWithOperator(t *testing.T) {
-	m := New[TestModel]().Where("age >", 18)
+	m := New[TestModel]().Where("age", ">", 18)
 	query, args := m.Print()
 
 	expected := "age > $1"
@@ -129,7 +129,7 @@ func TestWhere_StructConditions(t *testing.T) {
 // TestWhere_CallbackNested tests Where with callback for nested conditions
 func TestWhere_CallbackNested(t *testing.T) {
 	m := New[TestModel]().Where(func(q *Model[TestModel]) {
-		q.Where("age >", 18).Where("age <", 65)
+		q.Where("age", ">", 18).Where("age", "<", 65)
 	})
 	query, args := m.Print()
 
@@ -428,7 +428,7 @@ func TestGetArgs(t *testing.T) {
 func TestMethodChaining(t *testing.T) {
 	m := New[TestModel]().
 		Select("id", "name").
-		Where("age >", 18).
+		Where("age", ">", 18).
 		Where("status", "active").
 		OrderBy("created_at", "DESC").
 		Limit(10).
@@ -465,7 +465,7 @@ func TestComplexQuery(t *testing.T) {
 	m := New[TestModel]().
 		Select("name", "COUNT(*) as count").
 		Where(func(q *Model[TestModel]) {
-			q.Where("age >", 18).OrWhere("status", "verified")
+			q.Where("age", ">", 18).OrWhere("status", "verified")
 		}).
 		GroupBy("name").
 		Having("COUNT(*) >", 5).

--- a/query_test.go
+++ b/query_test.go
@@ -601,3 +601,13 @@ func TestChunkCallback_Logic(t *testing.T) {
 		t.Logf("Expected error without database: %v", err)
 	}
 }
+
+func TestWhereDefaultCase(t *testing.T) {
+	m := New[TestModel]()
+	m.Where("age", ">", 18, "extra") // 3 args → triggers default
+
+	// Nothing breaks, just ensure it returns the model
+	if m == nil {
+		t.Error("expected model instance, got nil")
+	}
+}


### PR DESCRIPTION
Refactor Where query syntax for clarity and consistency
This change updates the Where method API to separate the column, operator, and value.

Before
Where("col >", value)


After
Where("col", ">", value)

If no operator is provided, the method now defaults to "=":
Where("col", value)

This makes query construction more explicit, easier to read, and less error-prone while preserving existing behavior at the SQL level.