### PR TITLE
fix: resolve linter issues for context parameter order and else block

### DIFF
--- a/query.go
+++ b/query.go
@@ -527,10 +527,9 @@ func (m *Model[T]) whereHasInternal(relation string, subQuery any) *Model[T] {
 			if method.Type.In(0).Kind() == reflect.Pointer {
 				retVals := method.Func.Call([]reflect.Value{ptrValue})
 				return m.applyWhereHas(retVals, subQuery)
-			} else {
-				retVals := method.Func.Call([]reflect.Value{res0})
-				return m.applyWhereHas(retVals, subQuery)
 			}
+			retVals := method.Func.Call([]reflect.Value{res0})
+			return m.applyWhereHas(retVals, subQuery)
 		}
 		return m
 	}
@@ -593,7 +592,7 @@ func (m *Model[T]) applyWhereHas(retVals []reflect.Value, subQuery any) *Model[T
 		fnVal := reflect.ValueOf(subQuery)
 		if fnVal.Kind() == reflect.Func {
 			// Create a new model for the related type
-			relatedModel := rel.NewModel(m.db, m.ctx)
+			relatedModel := rel.NewModel(m.ctx, m.db)
 			if relatedModel != nil {
 				fnVal.Call([]reflect.Value{reflect.ValueOf(relatedModel)})
 				// Extract constraints from the populated model

--- a/relations.go
+++ b/relations.go
@@ -107,12 +107,12 @@ type MorphMany[T any] struct {
 type Relation interface {
 	RelationType() RelationType
 	NewRelated() any
-	NewModel(db *sql.DB, ctx context.Context) any
+	NewModel(ctx context.Context, db *sql.DB) any
 }
 
 func (HasOne[T]) RelationType() RelationType { return RelationHasOne }
 func (HasOne[T]) NewRelated() any            { return new(T) }
-func (HasOne[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (HasOne[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx
@@ -121,7 +121,7 @@ func (HasOne[T]) NewModel(db *sql.DB, ctx context.Context) any {
 
 func (HasMany[T]) RelationType() RelationType { return RelationHasMany }
 func (HasMany[T]) NewRelated() any            { return new(T) }
-func (HasMany[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (HasMany[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx
@@ -130,7 +130,7 @@ func (HasMany[T]) NewModel(db *sql.DB, ctx context.Context) any {
 
 func (BelongsTo[T]) RelationType() RelationType { return RelationBelongsTo }
 func (BelongsTo[T]) NewRelated() any            { return new(T) }
-func (BelongsTo[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (BelongsTo[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx
@@ -139,7 +139,7 @@ func (BelongsTo[T]) NewModel(db *sql.DB, ctx context.Context) any {
 
 func (BelongsToMany[T]) RelationType() RelationType { return RelationBelongsToMany }
 func (BelongsToMany[T]) NewRelated() any            { return new(T) }
-func (BelongsToMany[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (BelongsToMany[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx
@@ -165,11 +165,11 @@ const (
 
 func (MorphTo[T]) RelationType() RelationType                   { return RelationMorphTo }
 func (MorphTo[T]) NewRelated() any                              { return nil } // Dynamic
-func (MorphTo[T]) NewModel(db *sql.DB, ctx context.Context) any { return nil }
+func (MorphTo[T]) NewModel(ctx context.Context, db *sql.DB) any { return nil }
 
 func (MorphOne[T]) RelationType() RelationType { return RelationMorphOne }
 func (MorphOne[T]) NewRelated() any            { return new(T) }
-func (MorphOne[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (MorphOne[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx
@@ -178,7 +178,7 @@ func (MorphOne[T]) NewModel(db *sql.DB, ctx context.Context) any {
 
 func (MorphMany[T]) RelationType() RelationType { return RelationMorphMany }
 func (MorphMany[T]) NewRelated() any            { return new(T) }
-func (MorphMany[T]) NewModel(db *sql.DB, ctx context.Context) any {
+func (MorphMany[T]) NewModel(ctx context.Context, db *sql.DB) any {
 	m := New[T]()
 	m.db = db
 	m.ctx = ctx


### PR DESCRIPTION
- Move context.Context to first parameter in Relation.NewModel interface
- Update all NewModel implementations (HasOne, HasMany, BelongsTo, BelongsToMany, MorphTo, MorphOne, MorphMany)
- Remove unnecessary else block after return in WhereHas
